### PR TITLE
Fullscreen glow effect

### DIFF
--- a/assets/shaders/innerglow.frag
+++ b/assets/shaders/innerglow.frag
@@ -1,0 +1,38 @@
+#version 300 es
+
+precision mediump float;
+
+uniform sampler2D SRC_CHANNEL;
+
+vec4 CHANNEL_0;
+vec4 COLOR;
+vec2 UV;
+vec2 SIZE;
+
+vec4 DST;
+vec4 SRC;
+
+//<indigo-fragment>
+layout (std140) uniform InnerGlowData {
+  vec4 GLOW_COLOR;
+  // TODO: amount
+  // TODO: width
+  // TODO: height
+};
+
+float sdfCalc(vec2 p, vec2 b){
+  vec2 d = abs(p) - b;
+  return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0);
+}
+
+void fragment(){
+
+  float amount = clamp(0.25, 0.0, 1.0);
+  vec2 aspect = vec2(1.0, 1.0 + (500.0 / 800.0));
+
+  float sdf = sdfCalc((UV * 2.0) - 1.0, vec2(1.0) - (vec2(amount, amount) * aspect));
+
+  COLOR = SRC + vec4(vec3(sdf), 1.0);
+
+}
+//</indigo-fragment>

--- a/assets/shaders/innerglow.frag
+++ b/assets/shaders/innerglow.frag
@@ -32,7 +32,8 @@ void fragment(){
 
   float sdf = sdfCalc((UV * 2.0) - 1.0, vec2(1.0) - (vec2(amount, amount) * aspect));
 
-  COLOR = SRC + vec4(vec3(sdf), 1.0);
+  vec4 glow = vec4(GLOW_COLOR.rgb * sdf, sdf);
 
+  COLOR = mix(glow, SRC, SRC.a);
 }
 //</indigo-fragment>

--- a/assets/shaders/innerglow.frag
+++ b/assets/shaders/innerglow.frag
@@ -2,24 +2,21 @@
 
 precision mediump float;
 
-uniform sampler2D SRC_CHANNEL;
-
-vec4 CHANNEL_0;
 vec4 COLOR;
 vec2 UV;
-vec2 SIZE;
 
-vec4 DST;
 vec4 SRC;
 
 //<indigo-fragment>
+
+// The field order looks random, but its important for data packing.
 layout (std140) uniform InnerGlowData {
   vec4 GLOW_COLOR;
-  // TODO: amount
-  // TODO: width
-  // TODO: height
+  vec2 SCREEN_SIZE;
+  float INTENSITY;
 };
 
+// Calculates the distance of the current fragment to the edge of a box.
 float sdfCalc(vec2 p, vec2 b){
   vec2 d = abs(p) - b;
   return length(max(d, 0.0)) + min(max(d.x, d.y), 0.0);
@@ -27,13 +24,32 @@ float sdfCalc(vec2 p, vec2 b){
 
 void fragment(){
 
-  float amount = clamp(0.25, 0.0, 1.0);
-  vec2 aspect = vec2(1.0, 1.0 + (500.0 / 800.0));
+  // Make sure the intensity is a sensible value and invert.
+  float intensity = 1.0 - clamp(INTENSITY, 0.05, 0.95);
 
-  float sdf = sdfCalc((UV * 2.0) - 1.0, vec2(1.0) - (vec2(amount, amount) * aspect));
+  // Work out the aspect ratio to make the glow even. Assumes width > height.
+  float aspect = SCREEN_SIZE.x / SCREEN_SIZE.y;
 
-  vec4 glow = vec4(GLOW_COLOR.rgb * sdf, sdf);
+  // Shift the UV to be around the origin.
+  vec2 p = ((UV * 2.0) - 1.0) * aspect;
 
-  COLOR = mix(glow, SRC, SRC.a);
+  // Distance to the boundary from the origin
+  vec2 b = vec2(aspect);
+
+  // Work out the magic sdf distance value.
+  float sdf = abs(sdfCalc(p, b));
+
+  // Massage it into a nice shape.
+  sdf = 1.0 - sdf;
+  sdf = pow(sdf, 10.0 * intensity);
+  sdf = smoothstep(0.0, 1.0, sdf);
+
+  // Create the glow colour, remembering to account for premultiplied alpha.
+  float alpha = sdf * GLOW_COLOR.a;
+  vec4 glow = vec4(GLOW_COLOR.rgb * alpha, alpha);
+
+  // Blend the normal colours of the layer with the glow.
+  COLOR = mix(SRC, glow, glow.a);
+
 }
 //</indigo-fragment>

--- a/gamedata/assets.md
+++ b/gamedata/assets.md
@@ -1,6 +1,7 @@
 Name|type|phase|path
 ---|---|---|---
 TextFragShader|text|init|assets/shaders/text.frag
+InnerGlow|text|init|assets/shaders/innerglow.frag
 TileMap|image|init|assets/Anikki_square_10x10.png
 indigoLogo|image|init|assets/indigoLogo.png
 purpleKingdomLogo|image|init|assets/pkLogo.png

--- a/src/main/scala/roguelike/LoadingScene.scala
+++ b/src/main/scala/roguelike/LoadingScene.scala
@@ -12,7 +12,6 @@ import roguelike.model.Loader
 import roguelike.model.LoadingState
 import roguelike.model.Model
 import roguelike.model.ModelSaveData
-import roguelike.screeneffects.InnerGlow
 import roguelike.viewmodel.ViewModel
 
 object LoadingScene extends Scene[Size, Model, ViewModel]:
@@ -123,8 +122,6 @@ object LoadingScene extends Scene[Size, Model, ViewModel]:
               (midX - (loaderBounds.width * 0.5)).toInt,
               (midY - (loaderBounds.height * 0.5)).toInt
             )
-        ).withBlendMaterial(InnerGlow)
+        )
       )
     )
-
-

--- a/src/main/scala/roguelike/LoadingScene.scala
+++ b/src/main/scala/roguelike/LoadingScene.scala
@@ -2,6 +2,7 @@ package roguelike
 
 import indigo.*
 import indigo.scenes.*
+import indigo.syntax.*
 import indigoextras.subsystems.AssetBundleLoader
 import indigoextras.subsystems.AssetBundleLoaderEvent
 import io.indigoengine.roguelike.starterkit.*
@@ -11,6 +12,7 @@ import roguelike.model.Loader
 import roguelike.model.LoadingState
 import roguelike.model.Model
 import roguelike.model.ModelSaveData
+import roguelike.screeneffects.InnerGlow
 import roguelike.viewmodel.ViewModel
 
 object LoadingScene extends Scene[Size, Model, ViewModel]:
@@ -114,11 +116,15 @@ object LoadingScene extends Scene[Size, Model, ViewModel]:
 
     Outcome(
       SceneUpdateFragment(
-        loader
-          .view()
-          .moveTo(
-            (midX - (loaderBounds.width * 0.5)).toInt,
-            (midY - (loaderBounds.height * 0.5)).toInt
-          )
+        Layer(
+          loader
+            .view()
+            .moveTo(
+              (midX - (loaderBounds.width * 0.5)).toInt,
+              (midY - (loaderBounds.height * 0.5)).toInt
+            )
+        ).withBlendMaterial(InnerGlow)
       )
     )
+
+

--- a/src/main/scala/roguelike/MainMenuScene.scala
+++ b/src/main/scala/roguelike/MainMenuScene.scala
@@ -11,6 +11,7 @@ import roguelike.game.GameScene
 import roguelike.model.Message
 import roguelike.model.Model
 import roguelike.model.SceneTime
+import roguelike.screeneffects.InnerGlow
 import roguelike.viewmodel.ViewModel
 
 object MainMenuScene extends Scene[Size, Model, ViewModel]:

--- a/src/main/scala/roguelike/RogueLikeGame.scala
+++ b/src/main/scala/roguelike/RogueLikeGame.scala
@@ -7,6 +7,7 @@ import io.indigoengine.roguelike.starterkit.*
 import roguelike.assets.GameAssets
 import roguelike.game.GameScene
 import roguelike.model.Model
+import roguelike.screeneffects.InnerGlow
 import roguelike.subsystems.FloatingMessage
 import roguelike.viewmodel.ViewModel
 
@@ -58,7 +59,7 @@ object RogueLikeGame extends IndigoGame[Size, Size, Model, ViewModel]:
       )
         .withFonts(RoguelikeTiles.Size10x10.Fonts.fontInfo)
         .withAssets(GameAssets.initialAssets)
-        .withShaders(TerminalText.standardShader)
+        .withShaders(TerminalText.standardShader, InnerGlow.shader)
         .withSubSystems(
           FPSCounter(
             Point(5, 100),

--- a/src/main/scala/roguelike/screeneffects/InnerGlow.scala
+++ b/src/main/scala/roguelike/screeneffects/InnerGlow.scala
@@ -5,21 +5,29 @@ import indigo.scenes.*
 import indigo.syntax.*
 import roguelike.assets.GameAssets
 
-case object InnerGlow extends BlendMaterial:
+final case class InnerGlow(
+    screenSize: Size,
+    colour: RGBA,
+    intensity: Double
+) extends BlendMaterial:
+
+  def toShaderData: BlendShaderData =
+    BlendShaderData(
+      InnerGlow.shaderId,
+      UniformBlock(
+        "InnerGlowData",
+        Batch(
+          Uniform("GLOW_COLOR")  -> vec4.fromRGBA(colour),
+          Uniform("SCREEN_SIZE") -> vec2.fromSize(screenSize),
+          Uniform("INTENSITY")   -> float(intensity)
+        )
+      )
+    )
+
+object InnerGlow:
   val shaderId: ShaderId = ShaderId("inner glow blend material")
 
   val shader: BlendShader.External =
     BlendShader
       .External(shaderId)
       .withFragmentProgram(GameAssets.InnerGlow)
-
-  def toShaderData: BlendShaderData =
-    BlendShaderData(
-      shaderId,
-      UniformBlock(
-        "InnerGlowData",
-        Batch(
-          Uniform("GLOW_COLOR") -> vec4.fromRGBA(RGBA.Red)
-        )
-      )
-    )

--- a/src/main/scala/roguelike/screeneffects/InnerGlow.scala
+++ b/src/main/scala/roguelike/screeneffects/InnerGlow.scala
@@ -1,0 +1,25 @@
+package roguelike.screeneffects
+
+import indigo.*
+import indigo.scenes.*
+import indigo.syntax.*
+import roguelike.assets.GameAssets
+
+case object InnerGlow extends BlendMaterial:
+  val shaderId: ShaderId = ShaderId("inner glow blend material")
+
+  val shader: BlendShader.External =
+    BlendShader
+      .External(shaderId)
+      .withFragmentProgram(GameAssets.InnerGlow)
+
+  def toShaderData: BlendShaderData =
+    BlendShaderData(
+      shaderId,
+      UniformBlock(
+        "InnerGlowData",
+        Batch(
+          Uniform("GLOW_COLOR") -> vec4.fromRGBA(RGBA.Red)
+        )
+      )
+    )


### PR DESCRIPTION
This adds the ability to put a glow around the edge of the screen using a blend material attached to a layer.

The usage is:

```scala
Layer(BindingKey("My layer"))
  .withBlendMaterial(
    InnerGlow(Size(800, 500), RGBA.Black.withAlpha(0.6), 0.45)
)
```

Here is it being used to add the soft black shadow around the edge of the screen.

![image](https://user-images.githubusercontent.com/908709/193220763-63806642-1695-4e2a-8d5e-0e7e1a92d1de.png)
